### PR TITLE
Migrate tools scripts to Python 3

### DIFF
--- a/opentrials/tools/check_published.py
+++ b/opentrials/tools/check_published.py
@@ -1,20 +1,22 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
-import urllib2
+from http.client import HTTPConnection
 
-import httplib
-
-SERVER = 'www.ensaiosclinicos.gov.br' 
+SERVER = 'www.ensaiosclinicos.gov.br'
 PATH = '/rg/%s/'
 
-with open(sys.argv[1], 'r') as id_file:
-    for i, trial_id in list(enumerate(id_file)):
+with open(sys.argv[1], 'r', encoding='utf-8') as id_file:
+    for i, trial_id in enumerate(id_file, start=1):
         trial_id = trial_id.strip()
-        print '*'*50, i+1, trial_id
-        cnx = httplib.HTTPConnection(SERVER)
-        cnx.request('GET', PATH % trial_id)
-        res = cnx.getresponse()
-        print res.status, res.reason
-        cnx.close()
+        if not trial_id:
+            continue
+        print('*' * 50, i, trial_id)
+        connection = HTTPConnection(SERVER)
+        try:
+            connection.request('GET', PATH % trial_id)
+            response = connection.getresponse()
+            print(response.status, response.reason)
+        finally:
+            connection.close()
 

--- a/opentrials/tools/gen_dump.py
+++ b/opentrials/tools/gen_dump.py
@@ -1,11 +1,26 @@
-from settings import INSTALLED_APPS
+#!/usr/bin/env python3
 
-print 'rm -rf rebec-2011-12-13'
-print 'mkdir rebec-2011-12-13'
+import sys
+from importlib import import_module
+from pathlib import Path
+
+here = Path(__file__).resolve().parent
+project_root = here.parent
+repo_root = project_root.parent
+
+for path in {project_root, repo_root}:
+    str_path = str(path)
+    if str_path not in sys.path:
+        sys.path.append(str_path)
+
+INSTALLED_APPS = import_module('opentrials.settings').INSTALLED_APPS
+
+print('rm -rf rebec-2011-12-13')
+print('mkdir rebec-2011-12-13')
 for app in INSTALLED_APPS:
     if app.startswith('django.contrib.'):
-        short_app = app.replace('django.contrib.','')
+        short_app = app.replace('django.contrib.', '')
     else:
         short_app = app
     cmd = './manage.py dumpdata -n %s --indent=2 > rebec-2011-12-13/%s-2011-12-13.json'
-    print cmd % (short_app, app)
+    print(cmd % (short_app, app))

--- a/opentrials/tools/get_published_trial_ids.py
+++ b/opentrials/tools/get_published_trial_ids.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from urllib import urlopen
 import re
+from urllib.request import urlopen
 
 BASE = 'http://www.ensaiosclinicos.gov.br/rg/?page='
 
@@ -11,12 +11,10 @@ re_link = re.compile(
 re_current = re.compile(r'''<span class="current">\s*(\d+)\s*</span>''')
 
 page = 1
-html_ant = ''
-
 trial_ids = []
 while True:
-    #print '*' * 50, page
-    html = urlopen(BASE+str(page)).read()
+    with urlopen(BASE + str(page)) as response:
+        html = response.read().decode('utf-8')
     res = re_current.findall(html)
     if len(res) == 0:
         break
@@ -26,7 +24,7 @@ while True:
     trial_ids.extend(res)
     page += 1
 for t in trial_ids:
-    print t
+    print(t)
 
 
 # em 2011-12-14 este script, bem como a inpeção visual da lista pública de 


### PR DESCRIPTION
## Summary
- port the opentrials tooling scripts to Python 3 syntax and stdlib APIs
- initialize Django via DJANGO_SETTINGS_MODULE and ensure unicode-safe file access where needed
- clean up environment path handling for tool imports

## Testing
- python3 -m compileall opentrials/tools

------