### PR TITLE
Replace unicode APIs with Python 3 string helpers

### DIFF
--- a/opentrials/assistance/models.py
+++ b/opentrials/assistance/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.contenttypes import generic
 
 from polyglot.models import Translation
@@ -13,7 +13,7 @@ class Category(models.Model):
     label = models.CharField(_('Label'), max_length=255, unique=True)
     translations = generic.GenericRelation('CategoryTranslation')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.label
 
 class CategoryTranslation(Translation):
@@ -34,7 +34,7 @@ class Question(models.Model):
             self.order = self.id*10
             self.save()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.title
 
 class QuestionTranslation(Translation):
@@ -59,7 +59,7 @@ class FieldHelp(models.Model):
 
     translations = generic.GenericRelation('FieldHelpTranslation')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.text
     
     def natural_key(self):

--- a/opentrials/flatpages_polyglot/models.py
+++ b/opentrials/flatpages_polyglot/models.py
@@ -8,7 +8,7 @@ class FlatPageTranslation(Translation):
     title = models.CharField(max_length=255, blank=True)
     content = models.TextField(max_length=2000, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.title
 
 FlatPage.translations = generic.GenericRelation(FlatPageTranslation)

--- a/opentrials/polyglot/models.py
+++ b/opentrials/polyglot/models.py
@@ -21,7 +21,7 @@ from django.db import models
 
 from django.contrib.contenttypes import generic
 from django.contrib.contenttypes.models import ContentType
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ObjectDoesNotExist
@@ -97,7 +97,7 @@ class Translation(models.Model):
         abstract = True
         unique_together = (('content_type','object_id','language'),)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.language
 
     def natural_key(self):

--- a/opentrials/polyglot/multilingual_forms.py
+++ b/opentrials/polyglot/multilingual_forms.py
@@ -27,7 +27,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import EMPTY_VALUES
 from django.forms.models import BaseModelFormSet
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.forms.models import modelformset_factory as django_modelformset_factory
 from django.forms.formsets import DELETION_FIELD_NAME
 

--- a/opentrials/polyglot/tests/02-forms.txt
+++ b/opentrials/polyglot/tests/02-forms.txt
@@ -148,7 +148,7 @@ When a form is instantiated, the choices of a multilingual choice field are show
 on the display language informed.
 
     >>> data = {
-    ...     'page': unicode(page.pk),
+    ...     'page': str(page.pk),
     ...     'information': 'Nothing important here.',
     ... }
 
@@ -159,7 +159,7 @@ on the display language informed.
     ...     display_language='pt-br',
     ... )
 
-    >>> renderized = form.fields['page'].widget.render('page', unicode(page.pk))
+    >>> renderized = form.fields['page'].widget.render('page', str(page.pk))
     >>> (renderized.startswith(u'<select name="page">'),
     ... u'>Sobre o Teste<' in renderized,
     ... u' selected="selected">Título em português brasileiro<' in renderized,

--- a/opentrials/registration/admin.py
+++ b/opentrials/registration/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.contrib.sites.models import RequestSite
 from django.contrib.sites.models import Site
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from registration.models import RegistrationProfile
 

--- a/opentrials/registration/forms.py
+++ b/opentrials/registration/forms.py
@@ -6,7 +6,7 @@ Forms and validation code for user registration.
 
 from django.contrib.auth.models import User
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 # I put this on all required fields, because it's easier to pick up

--- a/opentrials/registration/models.py
+++ b/opentrials/registration/models.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.db import transaction
 from django.template.loader import render_to_string
 from django.utils.hashcompat import sha_constructor
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 SHA1_RE = re.compile('^[a-f0-9]{40}$')
@@ -93,9 +93,7 @@ class RegistrationManager(models.Manager):
         
         """
         salt = sha_constructor(str(random.random())).hexdigest()[:5]
-        username = user.username
-        if isinstance(username, unicode):
-            username = username.encode('utf-8')
+        username = str(user.username)
         activation_key = sha_constructor(salt+username).hexdigest()
         return self.create(user=user,
                            activation_key=activation_key)
@@ -174,8 +172,8 @@ class RegistrationProfile(models.Model):
         verbose_name = _('registration profile')
         verbose_name_plural = _('registration profiles')
     
-    def __unicode__(self):
-        return u"Registration information for %s" % self.user
+    def __str__(self):
+        return f"Registration information for {self.user}"
     
     def activation_key_expired(self):
         """

--- a/opentrials/registration/tests/models.py
+++ b/opentrials/registration/tests/models.py
@@ -41,7 +41,7 @@ class RegistrationModelTests(TestCase):
         self.assertEqual(RegistrationProfile.objects.count(), 1)
         self.assertEqual(profile.user.id, new_user.id)
         self.failUnless(re.match('^[a-f0-9]{40}$', profile.activation_key))
-        self.assertEqual(unicode(profile),
+        self.assertEqual(str(profile),
                          "Registration information for alice")
 
     def test_activation_email(self):

--- a/opentrials/repository/admin.py
+++ b/opentrials/repository/admin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from django.contrib import admin
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.utils.functional import update_wrapper
 from django.http import HttpResponseRedirect
 from django.db import models
@@ -149,8 +149,14 @@ class PublishedTrialAdmin(admin.ModelAdmin):
 
         # Other children objects
         for name, value in values_dict.items():
-            if name in ('__model__','scientific_acronym_display','acronym_display','pk',
-                    '__unicode__','date_enrollment_start',):
+            if name in (
+                '__model__',
+                'scientific_acronym_display',
+                'acronym_display',
+                'pk',
+                '__str__',
+                'date_enrollment_start',
+            ):
                 continue
 
             extra_context['trial_fields'].append({

--- a/opentrials/repository/choices.py
+++ b/opentrials/repository/choices.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 ## Qualifiers for the relationship of secondary entities with a ClinicalTrial #
 

--- a/opentrials/repository/feed.py
+++ b/opentrials/repository/feed.py
@@ -1,5 +1,5 @@
 from django.contrib.syndication.feeds import Feed
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from repository.models import ClinicalTrial
 
 class LastTrials(Feed):

--- a/opentrials/repository/models.py
+++ b/opentrials/repository/models.py
@@ -1,6 +1,6 @@
 from django.db import models, IntegrityError
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.html import linebreaks
 from django.contrib.contenttypes import generic
 from django.contrib.contenttypes.models import ContentType
@@ -76,7 +76,7 @@ class TrialRegistrationDataSetModel(ControlledDeletion):
                 seen.add(value.__class__.__name__)
                 content = '<table bgcolor="yellow">%s</table>' % value.html_dump(seen, follow_sets=False)
             else:
-                content = unicode(value)
+                content = str(value)
                 if u'\n' in content:
                     content = linebreaks(content)
             html.append('<tr><th>%s</th><td>%s</td></tr>' % (field.name, content))
@@ -96,7 +96,7 @@ class TrialRegistrationDataSetModel(ControlledDeletion):
                                 seen.add(rel_value.__class__.__name__)
                                 content = '<table>%s</table>' % rel_value.html_dump(seen, follow_sets=False)
                             else:
-                                content = unicode(rel_value)
+                                content = str(rel_value)
                             if u'\n' in content:
                                 content = linebreaks(content)
                             inner_html.append('<tr><th>%s</th><td>%s</td></tr>' % (id, content))
@@ -424,8 +424,8 @@ class ClinicalTrial(TrialRegistrationDataSetModel):
         else:
             return self.scientific_title
 
-    def __unicode__(self):
-        return u'%s %s' % (self.identifier(), self.short_title())
+    def __str__(self):
+        return f"{self.identifier()} {self.short_title()}"
 
     def trial_id_display(self):
         ''' return the trial id or an explicit message it is None '''
@@ -607,8 +607,8 @@ class TrialNumber(TrialRegistrationDataSetModel):
     id_number = models.CharField(_('Secondary Id Number'),
                                 max_length=255, db_index=True)
 
-    def __unicode__(self):
-        return u'%s: %s' % (self.issuing_authority, self.id_number)
+    def __str__(self):
+        return f"{self.issuing_authority}: {self.id_number}"
 
     def serialize_for_fossil(self, as_string=True):
         return serialize_trialnumber(self, as_string)
@@ -618,8 +618,8 @@ class TrialSecondarySponsor(TrialRegistrationDataSetModel):
     trial = models.ForeignKey(ClinicalTrial)
     institution = models.ForeignKey('Institution', verbose_name=_('Institution'))
 
-    def __unicode__(self):
-        return u'%s' % self.institution
+    def __str__(self):
+        return str(self.institution)
 
     def serialize_for_fossil(self, as_string=True):
         return serialize_trialsecondarysponsor(self, as_string)
@@ -629,8 +629,8 @@ class TrialSupportSource(TrialRegistrationDataSetModel):
     trial = models.ForeignKey(ClinicalTrial)
     institution = models.ForeignKey('Institution', verbose_name=_('Institution'))
 
-    def __unicode__(self):
-        return u'%s' % self.institution
+    def __str__(self):
+        return str(self.institution)
 
     def serialize_for_fossil(self, as_string=True):
         return serialize_trialsupportsource(self, as_string)
@@ -647,7 +647,7 @@ class Institution(TrialRegistrationDataSetModel):
     i_type = models.ForeignKey(InstitutionType, null=True, blank=True,
                                            verbose_name=_('Institution type'))
 
-    def __unicode__(self):
+    def __str__(self):
         return safe_truncate(self.name, 120)
 
     def serialize_for_fossil(self, as_string=True):
@@ -676,7 +676,7 @@ class Contact(TrialRegistrationDataSetModel):
         names = self.firstname + u' ' + self.middlename + u' ' + self.lastname
         return u' '.join(names.split())
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name()
 
     def serialize_for_fossil(self, as_string=True):
@@ -691,9 +691,11 @@ class PublicContact(TrialRegistrationDataSetModel):
     class Meta:
         unique_together = ('trial', 'contact')
 
-    def __unicode__(self):
-        return u'Public Contact for %s: %s (%s)' % (self.trial.short_title(),
-                                     self.contact.name(), self.status)
+    def __str__(self):
+        return (
+            f"Public Contact for {self.trial.short_title()}: {self.contact.name()}"
+            f" ({self.status})"
+        )
 
 class ScientificContact(TrialRegistrationDataSetModel):
     trial = models.ForeignKey(ClinicalTrial)
@@ -704,9 +706,11 @@ class ScientificContact(TrialRegistrationDataSetModel):
     class Meta:
         unique_together = ('trial', 'contact')
 
-    def __unicode__(self):
-        return u'Scientific Contact for %s: %s (%s)' % (self.trial.short_title(),
-                                     self.contact.name(), self.status)
+    def __str__(self):
+        return (
+            f"Scientific Contact for {self.trial.short_title()}: {self.contact.name()}"
+            f" ({self.status})"
+        )
 
 class SiteContact(TrialRegistrationDataSetModel):
     trial = models.ForeignKey(ClinicalTrial)
@@ -717,9 +721,11 @@ class SiteContact(TrialRegistrationDataSetModel):
     class Meta:
         unique_together = ('trial', 'contact')
 
-    def __unicode__(self):
-        return u'Site Contact for %s: %s (%s)' % (self.trial.short_title(),
-                                     self.contact.name(), self.status)
+    def __str__(self):
+        return (
+            f"Site Contact for {self.trial.short_title()}: {self.contact.name()}"
+            f" ({self.status})"
+        )
 
 # TRDS 19 - Primary Outcome(s)
 # TRDS 20 - Key Secondary Outcome(s)
@@ -736,7 +742,7 @@ class Outcome(TrialRegistrationDataSetModel):
     class Meta:
         order_with_respect_to = 'trial'
 
-    def __unicode__(self):
+    def __str__(self):
         return safe_truncate(self.description, 80)
 
     def translations_all(self):
@@ -766,8 +772,8 @@ class Descriptor(TrialRegistrationDataSetModel):
 
     translations = generic.GenericRelation('DescriptorTranslation')
 
-    def __unicode__(self):
-        return u'[%s] %s: %s' % (self.vocabulary, self.code, self.text)
+    def __str__(self):
+        return f"[{self.vocabulary}] {self.code}: {self.text}"
 
     def trial_identifier(self):
         return self.trial.identifier()

--- a/opentrials/repository/serializers.py
+++ b/opentrials/repository/serializers.py
@@ -96,7 +96,7 @@ def serialize_trial(trial, as_string=True, attrs_to_ignore=None):
             json['date_enrollment_start'] = '/'.join(date)
 
     # Meta or auxiliar attributes
-    json['__unicode__'] = unicode(trial)
+    json['__str__'] = str(trial)
     json['__model__'] = trial.__class__.__name__
     json['pk'] = trial.pk
 

--- a/opentrials/repository/templatetags/scoreboard.py
+++ b/opentrials/repository/templatetags/scoreboard.py
@@ -1,6 +1,6 @@
 from repository.models import ClinicalTrial, ClinicalTrialTranslation
 from django.template import Library, Node, TemplateSyntaxError
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 register = Library()
 

--- a/opentrials/repository/tests/02-serializing.txt
+++ b/opentrials/repository/tests/02-serializing.txt
@@ -27,8 +27,8 @@ Serializing
 
     >>> json_should_be = {
     ...     'pk': trial_small.pk,
-    ...     '__unicode__': unicode(trial_small),
-    ...     '__model__': unicode('ClinicalTrial'),
+    ...     '__str__': str(trial_small),
+    ...     '__model__': 'ClinicalTrial',
     ...     'id': trial_small.pk,
     ...     'trial_id': None,
     ...     'date_registration': None,
@@ -295,8 +295,8 @@ Serializing
 
     >>> json_should_be = {
     ...     'pk': trial_big.pk,
-    ...     '__unicode__': unicode(trial_big),
-    ...     '__model__': unicode('ClinicalTrial'),
+    ...     '__str__': str(trial_big),
+    ...     '__model__': 'ClinicalTrial',
     ...     'id': trial_big.pk,
     ...     'trial_id': trial_big.trial_id,
     ...     'date_registration': trial_big.date_registration.strftime('%Y-%m-%d %H:%M:%S'),
@@ -409,7 +409,7 @@ Small changes (changing a field of the clinical trial)
     >>> fossil_small1 != fossil_small2
     True
 
-    >>> fossil_small2.display_text == unicode(trial_small)
+    >>> fossil_small2.display_text == str(trial_small)
     True
 
 Changes on referenced (changing a foreign object that the current trial is dependent)
@@ -424,7 +424,7 @@ Changes on referenced (changing a foreign object that the current trial is depen
     >>> fossil_big1 != fossil_big2
     True
 
-    >>> fossil_big2.display_text == unicode(trial_big)
+    >>> fossil_big2.display_text == str(trial_big)
     True
 
 Testing fossil proxy object
@@ -437,7 +437,7 @@ Testing fossil proxy object
     >>> fossil_small2_obj.public_title == trial_small.public_title
     True
 
-    >>> unicode(fossil_small2_obj) == unicode(trial_small)
+    >>> str(fossil_small2_obj) == str(trial_small)
     True
 
 

--- a/opentrials/repository/trds.py
+++ b/opentrials/repository/trds.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from repository.models import *
 

--- a/opentrials/repository/trds_forms.py
+++ b/opentrials/repository/trds_forms.py
@@ -13,9 +13,9 @@ from repository.widgets import SelectWithLink, SelectInstitution, YearMonthWidge
 
 import choices
 
-from django.utils.encoding import force_unicode
+from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _, get_language
+from django.utils.translation import gettext_lazy as _, get_language
 from django.forms.formsets import DELETION_FIELD_NAME
 from django.template.defaultfilters import linebreaksbr
 
@@ -48,13 +48,13 @@ class ReviewModelForm(MultilingualBaseForm):
             bf_errors = self.error_class([conditional_escape(error) for error in bf.errors]) # Escape and cache in local variable.
             if bf.is_hidden:
                 if bf_errors:
-                    top_errors.extend([u'(Hidden field %s) %s' % (name, force_unicode(e)) for e in bf_errors])
-                hidden_fields.append(unicode(bf))
+                    top_errors.extend([u'(Hidden field %s) %s' % (name, force_str(e)) for e in bf_errors])
+                hidden_fields.append(str(bf))
             else:
                 if errors_on_separate_row and bf_errors:
-                    output.append(error_row % force_unicode(bf_errors))
+                    output.append(error_row % force_str(bf_errors))
                 if bf.label:
-                    label = conditional_escape(force_unicode(bf.label))
+                    label = conditional_escape(force_str(bf.label))
                     # Only add the suffix if the label does not end in
                     # punctuation.
                     if self.label_suffix:
@@ -81,7 +81,7 @@ class ReviewModelForm(MultilingualBaseForm):
                     field_status = ''
 
                 if field.help_text:
-                    help_text = help_text_html % force_unicode(field.help_text)
+                    help_text = help_text_html % force_str(field.help_text)
                 else:
                     help_text = u''
                 form_name = self.__class__.__name__
@@ -97,17 +97,17 @@ class ReviewModelForm(MultilingualBaseForm):
                         help_text = "%s<div class='help_text_example'>%s:<br />%s</div>" % (help_text, _("Example"), help_object.example)
 
                     if not help_text.strip():
-                        help_text = unicode(help_record)
+                        help_text = str(help_record)
                 except (FieldHelpTranslation.DoesNotExist, AttributeError):
                     help_text = "<div class='help_text'>%s</div>" % (help_record.text,)
                     if help_record.example:
                         help_text = "%s<div class='help_text_example'>%s:<br />%s</div>" % (help_text, _("Example"), help_record.example)
 
-                help_text = u'' + force_unicode(help_text)
+                help_text = force_str(help_text)
                 help_text = linebreaksbr(help_text_html % help_text)
-                output.append(normal_row % {'errors': force_unicode(bf_errors),
-                                            'label': force_unicode(label),
-                                            'field': unicode(bf),
+                output.append(normal_row % {'errors': force_str(bf_errors),
+                                            'label': force_str(label),
+                                            'field': str(bf),
                                             'help_text': help_text,
                                             'help_id': 'id_%s-help%s' % ((self.prefix or name),help_record.pk),
                                             'field_class': field_status,
@@ -120,7 +120,7 @@ class ReviewModelForm(MultilingualBaseForm):
                 self.Meta.count = self.Meta.count + 1
 
         if top_errors:
-            output.insert(0, error_row % force_unicode(top_errors))
+            output.insert(0, error_row % force_str(top_errors))
         if hidden_fields: # Insert any hidden fields in the last row.
             str_hidden = u''.join(hidden_fields)
 
@@ -408,7 +408,7 @@ class RecruitmentForm(ReviewModelForm):
 
     def clean_enrollment_end_date(self):
         if self.cleaned_data.get('recruitment_status'):
-            if self.cleaned_data.get('recruitment_status').label == unicode(_('recruiting')):
+            if self.cleaned_data.get('recruitment_status').label == str(_('recruiting')):
                 if self.cleaned_data.get('enrollment_end_date', None) is None:
                     raise forms.ValidationError(_("Recruiting trial requires an end date"))
 
@@ -417,7 +417,7 @@ class RecruitmentForm(ReviewModelForm):
 
     def clean_enrollment_start_date(self):
         if self.cleaned_data.get('recruitment_status'):
-            if self.cleaned_data.get('recruitment_status').label == unicode(_('recruiting')):
+            if self.cleaned_data.get('recruitment_status').label == str(_('recruiting')):
                 if self.cleaned_data.get('enrollment_start_date', None) is None:
                     raise forms.ValidationError(_("Recruiting trial requires a start date"))
 

--- a/opentrials/repository/trial_validation.py
+++ b/opentrials/repository/trial_validation.py
@@ -142,7 +142,7 @@ class TrialValidator(object):
                                                 else:
                                                     if step_status.get(lang, '') != MISSING:
                                                         step_status.update({lang: PARTIAL})
-                                            elif type(value) is str or type(value) is unicode:
+                                            elif isinstance(value, str):
                                                 if re.match('^\s*$', value):
                                                     if step_status.get(lang, '') != MISSING:
                                                         step_status.update({lang: MISSING})
@@ -187,7 +187,7 @@ class TrialValidator(object):
                                                     else:
                                                         if step_status.get(lang, '') != MISSING:
                                                             step_status.update({lang: PARTIAL})
-                                                elif type(value) is str or type(value) is unicode:
+                                                elif isinstance(value, str):
                                                     if re.match('^\s*$', value):
                                                         if check_fields[field]['required']:
                                                             step_status.update({lang: MISSING})

--- a/opentrials/repository/views.py
+++ b/opentrials/repository/views.py
@@ -9,7 +9,7 @@ from django.core import serializers
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseRedirect, HttpResponse, Http404
 from django.shortcuts import render_to_response, get_object_or_404
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.forms.models import inlineformset_factory
 from django.core.urlresolvers import reverse
 from django.contrib.auth.decorators import login_required
@@ -24,7 +24,7 @@ from django.contrib.sites.models import Site
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
 from django.contrib import messages
 from django.utils.translation import get_language
-from django.utils.encoding import smart_str, smart_unicode
+from django.utils.encoding import smart_str
 
 from reviewapp.models import Attachment, Submission, Remark
 from reviewapp.models import STATUS_PENDING, STATUS_RESUBMIT, STATUS_DRAFT, STATUS_APPROVED
@@ -132,8 +132,8 @@ def check_user_can_edit_trial(func):
         if request.ct.submission.status == STATUS_APPROVED:
             request.can_change_trial = False
             parsed_link = reverse(submission_edit_published, args=[trial_pk])
-            message_confirm_update = unicode(_("Updating a clinical trial, a new revision process will be started. Would you like to continue?"))
-            edit_trial_button_string = '<form action="%s" onsubmit="return window.confirm(\'%s\')"><input type="submit" value="%s"/> </form>' % (parsed_link,message_confirm_update,unicode(_('Update')))
+            message_confirm_update = str(_("Updating a clinical trial, a new revision process will be started. Would you like to continue?"))
+            edit_trial_button_string = '<form action="%s" onsubmit="return window.confirm(\'%s\')"><input type="submit" value="%s"/> </form>' % (parsed_link,message_confirm_update,str(_('Update')))
             messages.warning(request, _('This trial cannot be modified because it has already been approved.%s') % edit_trial_button_string)
 
         # Creator can edit in statuses draft and resubmited but can view on other statuses
@@ -670,7 +670,7 @@ def trial_registered(request, trial_fossil_id, trial_version=None):
     created = datetime.datetime.strptime(ct.fossil['created'], "%Y-%m-%d %H:%M:%S")
 
     if len(trial_fossil_id) == 64:
-        trial_fossil_id = unicode(fossil).split(' ')[0]
+        trial_fossil_id = str(fossil).split(' ')[0]
 
     trial = get_object_or_404(ClinicalTrial, trial_id=trial_fossil_id)
     attachs = [attach for attach in trial.trial_attach() if attach.public]
@@ -1398,7 +1398,7 @@ def custom_otcsv(request):
 
         try:
             trial_id = ClinicalTrial.objects.get(pk=submission['trial_id'])
-            trial_id = unicode(trial_id).split(' ')[0]
+            trial_id = str(trial_id).split(' ')[0]
         except:
             trial_id = "no_id"
 

--- a/opentrials/repository/widgets.py
+++ b/opentrials/repository/widgets.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.forms.util import flatatt
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.utils.dates import MONTHS
 
 from datetime import date, datetime

--- a/opentrials/reviewapp/admin.py
+++ b/opentrials/reviewapp/admin.py
@@ -55,8 +55,8 @@ class SubmissionAdmin(admin.ModelAdmin):
         super(SubmissionAdmin, self).save_model(request, instance, form, change)
         
 class RemarkAdmin(admin.ModelAdmin):
-    list_display = ('__unicode__', 'context', 'short_text', 'verified', 'status')
-    list_display_links = ('__unicode__', 'context', 'status')
+    list_display = ('__str__', 'context', 'short_text', 'verified', 'status')
+    list_display_links = ('__str__', 'context', 'status')
     search_fields = ('text', 'id', 'submission__id')
     list_filter = ('context', 'status', )
 
@@ -79,9 +79,16 @@ class NewsTranslationInline(TranslationInline):
         
 class NewsAdmin(TranslationAdmin):
     inlines = [NewsTranslationInline]
-    list_display = ('__unicode__', 'short_text', 'translation_completed', 
-                    'missing_translations', 'created', 'creator', 'status')
-    list_display_links = ('__unicode__', 'status')
+    list_display = (
+        '__str__',
+        'short_text',
+        'translation_completed',
+        'missing_translations',
+        'created',
+        'creator',
+        'status',
+    )
+    list_display_links = ('__str__', 'status')
     list_filter = ('created', 'status', 'translations')
     search_fields = ('title', 'text')
 

--- a/opentrials/reviewapp/consts.py
+++ b/opentrials/reviewapp/consts.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # Form validation util constants
 

--- a/opentrials/reviewapp/forms.py
+++ b/opentrials/reviewapp/forms.py
@@ -9,7 +9,7 @@ from opentrials.reviewapp.models import UserProfile
 from opentrials.reviewapp.models import Attachment, Submission
 from django import forms
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django.contrib.auth.models import User
 from django.conf import settings

--- a/opentrials/reviewapp/models.py
+++ b/opentrials/reviewapp/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from django.db import models
 from django.db.models.signals import post_save
 from django.contrib.auth.models import User
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.contenttypes import generic
 from django.utils import simplejson
 
@@ -100,7 +100,7 @@ class Submission(ControlledDeletion):
     def creator_username(self):
         return self.creator.username
 
-    def __unicode__(self):
+    def __str__(self):
         return self.short_title()
 
     def get_mandatory_languages(self):
@@ -194,8 +194,8 @@ class Attachment(models.Model):
     def get_relative_url(self):
         return self.file.url.replace(settings.PROJECT_PATH, u'')
 
-    def __unicode__(self):
-        return u"%s" % self.description
+    def __str__(self):
+        return str(self.description)
 
 REMARK_STATUS = [
     # initial state, as created by reviewer
@@ -242,8 +242,8 @@ class Remark(models.Model):
     status_acknowledged = RemarksAcknowledged()
     status_closed = RemarksClosed()
 
-    def __unicode__(self):
-        return '%s:%s' % (self.pk, self.submission_id)
+    def __str__(self):
+        return f"{self.pk}:{self.submission_id}"
 
     def short_text(self):
         return safe_truncate(self.text, 60)
@@ -275,8 +275,8 @@ class News(models.Model):
     def short_text(self):
         return safe_truncate(self.text, 240)
 
-    def __unicode__(self):
-        return '%s' % (self.short_title())
+    def __str__(self):
+        return str(self.short_title())
 
 class NewsTranslation(Translation):
     title = models.CharField(_('Title'), max_length=256)

--- a/opentrials/reviewapp/views.py
+++ b/opentrials/reviewapp/views.py
@@ -18,7 +18,7 @@ from django.contrib.sites.models import RequestSite
 from django.contrib.sites.models import Site
 from django.contrib.flatpages.models import FlatPage
 from django.contrib import messages
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.db.models import Q
 
 from flatpages_polyglot.models import FlatPageTranslation
@@ -57,7 +57,7 @@ def send_opentrials_email(subject, message, recipient):
         t = loader.get_template('reviewapp/email_contact.txt')
         c = Context({
                     'name': name,
-                    'message': unicode(message),
+                    'message': str(message),
                     'site_domain': Site.objects.get_current().domain,
                     'site_name': Site.objects.get_current().name, })
         send_mail(subject, t.render(c), from_email, recipient_list,

--- a/opentrials/tickets/models.py
+++ b/opentrials/tickets/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from datetime import datetime
 
@@ -23,8 +23,8 @@ class Ticket(models.Model):
         return ('ticket.history', [str(self.id)])
 
 
-    def __unicode__(self):
-        return u'%s' % (self.context)
+    def __str__(self):
+        return str(self.context)
 
     def save(self):
         self.updated = datetime.now()

--- a/opentrials/tickets/views.py
+++ b/opentrials/tickets/views.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import User
 from django.forms.models import inlineformset_factory
 from django.http import HttpResponseRedirect, HttpResponse
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.contrib.auth.decorators import login_required
 
 from opentrials.tickets.models import Ticket, Followup

--- a/opentrials/utilities.py
+++ b/opentrials/utilities.py
@@ -44,8 +44,7 @@ def safe_truncate(text, max_length=60, ellipsis=ELLIPSIS, encoding='utf-8',
           ...
         ValueError: Cannot safely truncate to 10 characters
     '''
-    if not isinstance(text, unicode):
-        text = text.decode(encoding)
+    text = str(text)
     if len(text) <= max_length:
         return text
     # reverse-seek a non-alphanumeric character

--- a/opentrials/vocabulary/models.py
+++ b/opentrials/vocabulary/models.py
@@ -1,7 +1,7 @@
 ############################################ Controlled Vocabularies ###
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.contenttypes import generic
 from django.utils import simplejson
 
@@ -24,7 +24,7 @@ class SimpleVocabulary(models.Model):
         abstract = True
         ordering = ['order']
 
-    def __unicode__(self):
+    def __str__(self):
         return self.label
 
     def natural_key(self):
@@ -78,7 +78,7 @@ class CountryCode(SimpleVocabulary):
     class Meta:
         ordering = ['description']
 
-    def __unicode__(self):
+    def __str__(self):
         return self.description
 
     @classmethod
@@ -133,13 +133,13 @@ class RecruitmentStatus(SimpleVocabulary):
 class DecsDisease(SimpleVocabulary):
     ''' TRDS 12 '''
 
-    def __unicode__(self):
+    def __str__(self):
         return self.description
 
 class IcdChapter(SimpleVocabulary):
     ''' TRDS 12 '''
 
-    def __unicode__(self):
+    def __str__(self):
         return self.description
 
 class AttachmentType(SimpleVocabulary):


### PR DESCRIPTION
## Summary
- replace model and admin `__unicode__` implementations with `__str__` and update serializers/tests to expect native strings
- switch from deprecated `ugettext` imports and `unicode()` calls to `gettext`/`str()` across views, forms, and helpers
- update form helpers to rely on `force_str`/`smart_str` and simplify `safe_truncate` to operate on native strings

## Testing
- python -m compileall opentrials *(fails due to legacy Python 2-only syntax in existing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d6daa9a7dc8327a968747a7fcfcd7d