### PR TITLE
Modernize diagnostic dumpdata utilities for Django 4.2

### DIFF
--- a/opentrials/diagnostic/tests/test_views.py
+++ b/opentrials/diagnostic/tests/test_views.py
@@ -1,0 +1,37 @@
+import json
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.urls import reverse
+
+
+class DumpDataViewTests(TestCase):
+    def setUp(self):
+        user_model = get_user_model()
+        self.staff_user = user_model.objects.create_user(
+            username="staff",
+            password="password",
+            is_staff=True,
+        )
+        self.client.force_login(self.staff_user)
+
+    def test_dumpdata_page_renders_template(self):
+        response = self.client.get(reverse("diagnostic:dumpdata"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "diagnostic/dumpdata.html")
+
+    def test_dumpdata_returns_json_for_specific_app(self):
+        response = self.client.get(reverse("diagnostic:dumpdata_app", args=["auth"]))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/json")
+        payload = json.loads(response.content)
+        self.assertTrue(any(item["model"] == "auth.user" for item in payload))
+
+    def test_dumpdata_post_allows_multiple_apps(self):
+        response = self.client.post(reverse("diagnostic:dumpdata"), {"apps": ["auth"]})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/json")
+        self.assertIn("choices_fixture.json", response["Content-Disposition"])

--- a/opentrials/diagnostic/urls.py
+++ b/opentrials/diagnostic/urls.py
@@ -1,14 +1,16 @@
-from django.conf.urls.defaults import *
+from django.urls import path
 
-from diagnostic.views import *
+from . import views
 
-urlpatterns = patterns('',
-    # Diagnostic views
-    url(r'^smoke/$', smoke_test),
-    url(r'^reqdump/$', req_dump),
-    url(r'^sysinfo/$', sys_info),
-    url(r'^error/$', raise_error),
-    url(r'^dumpdb/$', export_database),
-    url(r'^backupdb/$', backup_database, name='backup_database'),
-    url(r'^dumpdata/(?P<appname>[a-z_]+)?/?$', dump_data, name='dumpdata'),
-)
+app_name = "diagnostic"
+
+urlpatterns = [
+    path("smoke/", views.smoke_test, name="smoke_test"),
+    path("reqdump/", views.req_dump, name="req_dump"),
+    path("sysinfo/", views.sys_info, name="sys_info"),
+    path("error/", views.raise_error, name="raise_error"),
+    path("dumpdb/", views.export_database, name="dump_database"),
+    path("backupdb/", views.backup_database, name="backup_database"),
+    path("dumpdata/", views.dump_data, name="dumpdata"),
+    path("dumpdata/<str:appname>/", views.dump_data, name="dumpdata_app"),
+]


### PR DESCRIPTION
## Summary
- replace deprecated SortedDict/get_app usage with Django 4.x app registry lookups
- refresh diagnostic responses to use modern HttpResponse and render helpers
- add regression tests covering the dumpdata view behaviour

## Testing
- ❌ `DJANGO_SETTINGS_MODULE=opentrials.settings python -m django test opentrials.diagnostic` *(fails: No module named django in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7051fe0e88327be94349d24c7e257