### PR TITLE
Refactor legacy URL patterns to django.urls APIs

### DIFF
--- a/opentrials/assistance/urls.py
+++ b/opentrials/assistance/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls.defaults import *
+from django.urls import path
 
 from assistance.views import faq
 from assistance.models import Question
 
-urlpatterns = patterns('',
-    url(r'^faq/$', faq, name="assistance.faq"),
-)
+urlpatterns = [
+    path('faq/', faq, name="assistance.faq"),
+]

--- a/opentrials/decsclient/urls.py
+++ b/opentrials/decsclient/urls.py
@@ -1,10 +1,11 @@
-from django.conf.urls.defaults import *
+from django.urls import re_path
+
 from views import *
 
-urlpatterns = patterns('',
-    url(r'^getterm/(?P<lang>[a-z]{2,2})(-[a-z][a-z])?/(?P<code>[A-Z](\d{2,2}(\.\d{3,3})*)?)?$', getterm, name='decs.getterm'),
-    url(r'^getdescendants/(?P<code>[A-Z](\d{2,2}(\.\d{3,3})*)?)?$', getdescendants, name='decs.getdescendants'),
-    url(r'^search/(?P<lang>[a-z]{2,2})(-[a-z][a-z])?/(?P<prefix>[14]0[1-7])/(?P<term>.*)$', search),
-    url(r'^search/(?P<lang>[a-z]{2,2})(-[a-z][a-z])?/(?P<term>.*)$', search, name='decs.search'),
-    url(r'^test_search/$', test_search),
-)
+urlpatterns = [
+    re_path(r'^getterm/(?P<lang>[a-z]{2,2})(-[a-z][a-z])?/(?P<code>[A-Z](\d{2,2}(\.\d{3,3})*)?)?$', getterm, name='decs.getterm'),
+    re_path(r'^getdescendants/(?P<code>[A-Z](\d{2,2}(\.\d{3,3})*)?)?$', getdescendants, name='decs.getdescendants'),
+    re_path(r'^search/(?P<lang>[a-z]{2,2})(-[a-z][a-z])?/(?P<prefix>[14]0[1-7])/(?P<term>.*)$', search),
+    re_path(r'^search/(?P<lang>[a-z]{2,2})(-[a-z][a-z])?/(?P<term>.*)$', search, name='decs.search'),
+    re_path(r'^test_search/$', test_search),
+]

--- a/opentrials/icd10client/urls.py
+++ b/opentrials/icd10client/urls.py
@@ -1,9 +1,10 @@
-from django.conf.urls.defaults import *
+from django.urls import re_path
+
 from icd10client.views import *
 
-urlpatterns = patterns('',
-    url(r'^get_chapters/$', get_chapters, name='icd10.get_chapters'),
-    url(r'^search/(?P<lang>[a-z]{2,2})(-[a-z][a-z])?/(?P<prefix>\w+)/(?P<term>.*)$', search),
-    url(r'^search/(?P<lang>[a-z]{2,2})(-[a-z][a-z])?/(?P<term>.*)$', search, name='icd10.search'),
-    url(r'^test_search/$', test_search),
-)
+urlpatterns = [
+    re_path(r'^get_chapters/$', get_chapters, name='icd10.get_chapters'),
+    re_path(r'^search/(?P<lang>[a-z]{2,2})(-[a-z][a-z])?/(?P<prefix>\w+)/(?P<term>.*)$', search),
+    re_path(r'^search/(?P<lang>[a-z]{2,2})(-[a-z][a-z])?/(?P<term>.*)$', search, name='icd10.search'),
+    re_path(r'^test_search/$', test_search),
+]

--- a/opentrials/middleware/scriptprefix.py
+++ b/opentrials/middleware/scriptprefix.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import set_script_prefix
+from django.urls import set_script_prefix
 
 class ScriptPrefixMiddleware(object):
     """

--- a/opentrials/registration/auth_urls.py
+++ b/opentrials/registration/auth_urls.py
@@ -23,36 +23,36 @@ consult a specific backend's documentation for details.
 
 """
 
-from django.conf.urls.defaults import *
+from django.urls import path, re_path
 
 from django.contrib.auth import views as auth_views
 
 
-urlpatterns = patterns('',
-                       url(r'^login/$',
-                           auth_views.login,
-                           {'template_name': 'registration/login.html'},
-                           name='auth_login'),
-                       url(r'^logout/$',
-                           auth_views.logout,
-                           {'template_name': 'registration/logout.html'},
-                           name='auth_logout'),
-                       url(r'^password/change/$',
-                           auth_views.password_change,
-                           name='auth_password_change'),
-                       url(r'^password/change/done/$',
-                           auth_views.password_change_done,
-                           name='auth_password_change_done'),
-                       url(r'^password/reset/$',
-                           auth_views.password_reset,
-                           name='auth_password_reset'),
-                       url(r'^password/reset/confirm/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$',
-                           auth_views.password_reset_confirm,
-                           name='auth_password_reset_confirm'),
-                       url(r'^password/reset/complete/$',
-                           auth_views.password_reset_complete,
-                           name='auth_password_reset_complete'),
-                       url(r'^password/reset/done/$',
-                           auth_views.password_reset_done,
-                           name='auth_password_reset_done'),
-)
+urlpatterns = [
+    path('login/',
+         auth_views.login,
+         {'template_name': 'registration/login.html'},
+         name='auth_login'),
+    path('logout/',
+         auth_views.logout,
+         {'template_name': 'registration/logout.html'},
+         name='auth_logout'),
+    path('password/change/',
+         auth_views.password_change,
+         name='auth_password_change'),
+    path('password/change/done/',
+         auth_views.password_change_done,
+         name='auth_password_change_done'),
+    path('password/reset/',
+         auth_views.password_reset,
+         name='auth_password_reset'),
+    re_path(r'^password/reset/confirm/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$',
+            auth_views.password_reset_confirm,
+            name='auth_password_reset_confirm'),
+    path('password/reset/complete/',
+         auth_views.password_reset_complete,
+         name='auth_password_reset_complete'),
+    path('password/reset/done/',
+         auth_views.password_reset_done,
+         name='auth_password_reset_done'),
+]

--- a/opentrials/registration/backends/default/urls.py
+++ b/opentrials/registration/backends/default/urls.py
@@ -18,37 +18,37 @@ up your own URL patterns for these views instead.
 """
 
 
-from django.conf.urls.defaults import *
+from django.urls import include, path, re_path
 from django.views.generic.simple import direct_to_template
 
 from registration.views import activate
 from registration.views import register
 
 
-urlpatterns = patterns('',
-                       url(r'^activate/complete/$',
-                           direct_to_template,
-                           {'template': 'registration/activation_complete.html'},
-                           name='registration_activation_complete'),
-                       # Activation keys get matched by \w+ instead of the more specific
-                       # [a-fA-F0-9]{40} because a bad activation key should still get to the view;
-                       # that way it can return a sensible "invalid key" message instead of a
-                       # confusing 404.
-                       url(r'^activate/(?P<activation_key>\w+)/$',
-                           activate,
-                           {'backend': 'registration.backends.default.DefaultBackend'},
-                           name='registration_activate'),
-                       url(r'^register/$',
-                           register,
-                           {'backend': 'registration.backends.default.DefaultBackend'},
-                           name='registration_register'),
-                       url(r'^register/complete/$',
-                           direct_to_template,
-                           {'template': 'registration/registration_complete.html'},
-                           name='registration_complete'),
-                       url(r'^register/closed/$',
-                           direct_to_template,
-                           {'template': 'registration/registration_closed.html'},
-                           name='registration_disallowed'),
-                       (r'', include('registration.auth_urls')),
-                       )
+urlpatterns = [
+    path('activate/complete/',
+         direct_to_template,
+         {'template': 'registration/activation_complete.html'},
+         name='registration_activation_complete'),
+    # Activation keys get matched by \w+ instead of the more specific
+    # [a-fA-F0-9]{40} because a bad activation key should still get to the view;
+    # that way it can return a sensible "invalid key" message instead of a
+    # confusing 404.
+    re_path(r'^activate/(?P<activation_key>\w+)/$',
+            activate,
+            {'backend': 'registration.backends.default.DefaultBackend'},
+            name='registration_activate'),
+    path('register/',
+         register,
+         {'backend': 'registration.backends.default.DefaultBackend'},
+         name='registration_register'),
+    path('register/complete/',
+         direct_to_template,
+         {'template': 'registration/registration_complete.html'},
+         name='registration_complete'),
+    path('register/closed/',
+         direct_to_template,
+         {'template': 'registration/registration_closed.html'},
+         name='registration_disallowed'),
+    path('', include('registration.auth_urls')),
+]

--- a/opentrials/registration/backends/simple/urls.py
+++ b/opentrials/registration/backends/simple/urls.py
@@ -18,21 +18,21 @@ up your own URL patterns for these views instead.
 """
 
 
-from django.conf.urls.defaults import *
+from django.urls import include, path
 from django.views.generic.simple import direct_to_template
 
 from registration.views import activate
 from registration.views import register
 
 
-urlpatterns = patterns('',
-                       url(r'^register/$',
-                           register,
-                           {'backend': 'registration.backends.simple.SimpleBackend'},
-                           name='registration_register'),
-                       url(r'^register/closed/$',
-                           direct_to_template,
-                           {'template': 'registration/registration_closed.html'},
-                           name='registration_disallowed'),
-                       (r'', include('registration.auth_urls')),
-                       )
+urlpatterns = [
+    path('register/',
+         register,
+         {'backend': 'registration.backends.simple.SimpleBackend'},
+         name='registration_register'),
+    path('register/closed/',
+         direct_to_template,
+         {'template': 'registration/registration_closed.html'},
+         name='registration_disallowed'),
+    path('', include('registration.auth_urls')),
+]

--- a/opentrials/registration/tests/urls.py
+++ b/opentrials/registration/tests/urls.py
@@ -10,73 +10,73 @@ handled.
 
 """
 
-from django.conf.urls.defaults import *
+from django.urls import include, path, re_path
 from django.views.generic.simple import direct_to_template
 
 from registration.views import activate
 from registration.views import register
 
 
-urlpatterns = patterns('',
-                       # Test the 'activate' view with custom template
-                       # name.
-                       url(r'^activate-with-template-name/(?P<activation_key>\w+)/$',
-                           activate,
-                           {'template_name': 'registration/test_template_name.html',
-                            'backend': 'registration.backends.default.DefaultBackend'},
-                           name='registration_test_activate_template_name'),
-                       # Test the 'activate' view with
-                       # extra_context_argument.
-                       url(r'^activate-extra-context/(?P<activation_key>\w+)/$',
-                           activate,
-                           {'extra_context': {'foo': 'bar', 'callable': lambda: 'called'},
-                            'backend': 'registration.backends.default.DefaultBackend'},
-                           name='registration_test_activate_extra_context'),
-                       # Test the 'activate' view with success_url argument.
-                       url(r'^activate-with-success-url/(?P<activation_key>\w+)/$',
-                           activate,
-                           {'success_url': 'registration_test_custom_success_url',
-                            'backend': 'registration.backends.default.DefaultBackend'},
-                           name='registration_test_activate_success_url'),
-                       # Test the 'register' view with custom template
-                       # name.
-                       url(r'^register-with-template-name/$',
-                           register,
-                           {'template_name': 'registration/test_template_name.html',
-                            'backend': 'registration.backends.default.DefaultBackend'},
-                           name='registration_test_register_template_name'),
-                       # Test the'register' view with extra_context
-                       # argument.
-                       url(r'^register-extra-context/$',
-                           register,
-                           {'extra_context': {'foo': 'bar', 'callable': lambda: 'called'},
-                            'backend': 'registration.backends.default.DefaultBackend'},
-                           name='registration_test_register_extra_context'),
-                       # Test the 'register' view with custom URL for
-                       # closed registration.
-                       url(r'^register-with-disallowed-url/$',
-                           register,
-                           {'disallowed_url': 'registration_test_custom_disallowed',
-                            'backend': 'registration.backends.default.DefaultBackend'},
-                           name='registration_test_register_disallowed_url'),
-                       # Set up a pattern which will correspond to the
-                       # custom 'disallowed_url' above.
-                       url(r'^custom-disallowed/$',
-                           direct_to_template,
-                           {'template': 'registration/registration_closed.html'},
-                           name='registration_test_custom_disallowed'),
-                       # Test the 'register' view with custom redirect
-                       # on successful registration.
-                       url(r'^register-with-success_url/$',
-                           register,
-                           {'success_url': 'registration_test_custom_success_url',
-                            'backend': 'registration.backends.default.DefaultBackend'},
-                           name='registration_test_register_success_url'
-                           ),
-                       # Pattern for custom redirect set above.
-                       url(r'^custom-success/$',
-                           direct_to_template,
-                           {'template': 'registration/test_template_name.html'},
-                           name='registration_test_custom_success_url'),
-                       (r'', include('registration.backends.default.urls')),
-                       )
+urlpatterns = [
+    # Test the 'activate' view with custom template
+    # name.
+    re_path(r'^activate-with-template-name/(?P<activation_key>\w+)/$',
+            activate,
+            {'template_name': 'registration/test_template_name.html',
+             'backend': 'registration.backends.default.DefaultBackend'},
+            name='registration_test_activate_template_name'),
+    # Test the 'activate' view with
+    # extra_context_argument.
+    re_path(r'^activate-extra-context/(?P<activation_key>\w+)/$',
+            activate,
+            {'extra_context': {'foo': 'bar', 'callable': lambda: 'called'},
+             'backend': 'registration.backends.default.DefaultBackend'},
+            name='registration_test_activate_extra_context'),
+    # Test the 'activate' view with success_url argument.
+    re_path(r'^activate-with-success-url/(?P<activation_key>\w+)/$',
+            activate,
+            {'success_url': 'registration_test_custom_success_url',
+             'backend': 'registration.backends.default.DefaultBackend'},
+            name='registration_test_activate_success_url'),
+    # Test the 'register' view with custom template
+    # name.
+    path('register-with-template-name/',
+         register,
+         {'template_name': 'registration/test_template_name.html',
+          'backend': 'registration.backends.default.DefaultBackend'},
+         name='registration_test_register_template_name'),
+    # Test the'register' view with extra_context
+    # argument.
+    path('register-extra-context/',
+         register,
+         {'extra_context': {'foo': 'bar', 'callable': lambda: 'called'},
+          'backend': 'registration.backends.default.DefaultBackend'},
+         name='registration_test_register_extra_context'),
+    # Test the 'register' view with custom URL for
+    # closed registration.
+    path('register-with-disallowed-url/',
+         register,
+         {'disallowed_url': 'registration_test_custom_disallowed',
+          'backend': 'registration.backends.default.DefaultBackend'},
+         name='registration_test_register_disallowed_url'),
+    # Set up a pattern which will correspond to the
+    # custom 'disallowed_url' above.
+    path('custom-disallowed/',
+         direct_to_template,
+         {'template': 'registration/registration_closed.html'},
+         name='registration_test_custom_disallowed'),
+    # Test the 'register' view with custom redirect
+    # on successful registration.
+    path('register-with-success_url/',
+         register,
+         {'success_url': 'registration_test_custom_success_url',
+          'backend': 'registration.backends.default.DefaultBackend'},
+         name='registration_test_register_success_url'
+         ),
+    # Pattern for custom redirect set above.
+    path('custom-success/',
+         direct_to_template,
+         {'template': 'registration/test_template_name.html'},
+         name='registration_test_custom_success_url'),
+    path('', include('registration.backends.default.urls')),
+]

--- a/opentrials/registration/tests/views.py
+++ b/opentrials/registration/tests/views.py
@@ -3,7 +3,7 @@ import datetime
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 
 from registration import forms

--- a/opentrials/repository/admin.py
+++ b/opentrials/repository/admin.py
@@ -70,7 +70,7 @@ class PublishedTrialAdmin(admin.ModelAdmin):
     inlines = [InlineFossilIndexer]
 
     def get_urls(self):
-        from django.conf.urls.defaults import patterns, url
+        from django.urls import re_path
 
         default_urls = super(PublishedTrialAdmin, self).get_urls()
 
@@ -79,11 +79,11 @@ class PublishedTrialAdmin(admin.ModelAdmin):
                 return self.admin_site.admin_view(view)(*args, **kwargs)
             return update_wrapper(wrapper, view)
 
-        urlpatterns = patterns('',
-                url(r'^(.+)/display-off/$', wrap(self.set_display_off), name='fossil_set_display_off'),
-                url(r'^(.+)/display-on/$', wrap(self.set_display_on), name='fossil_set_display_on'),
-                )
-        
+        urlpatterns = [
+                re_path(r'^(?P<object_id>.+)/display-off/$', wrap(self.set_display_off), name='fossil_set_display_off'),
+                re_path(r'^(?P<object_id>.+)/display-on/$', wrap(self.set_display_on), name='fossil_set_display_on'),
+                ]
+
         return urlpatterns + default_urls
 
     def set_display_off(self, request, object_id):

--- a/opentrials/repository/models.py
+++ b/opentrials/repository/models.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes import generic
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 

--- a/opentrials/repository/urls.py
+++ b/opentrials/repository/urls.py
@@ -1,39 +1,35 @@
-from django.conf.urls.defaults import *
-from django.views.generic.list_detail import object_detail, object_list
-
-from repository.models import ClinicalTrial
+from django.urls import path, re_path
 
 from repository.views import edit_trial_index, full_view, index, step_1, step_2, step_3
 from repository.views import step_4, step_5, step_6, step_7, step_8, step_9, new_institution
 from repository.views import trial_registered, trial_view, recruiting, trial_ictrp, trial_otxml
 from repository.views import all_trials_ictrp, contacts, advanced_search, multi_otxml, custom_otcsv
 
-
-urlpatterns = patterns('',
-    url(r'^edit/(\d+)/$', edit_trial_index, name='repository.edittrial'),
-    url(r'^view/(?P<trial_pk>\d+)/$', trial_view, name='repository.trialview'),
-    url(r'^new_institution/$', new_institution, name='new_institution'),
-    url(r'^contacts/$', contacts, name='contacts'),
-    url(r'^step_1/(\d+)/$', step_1, name='step_1'),
-    url(r'^step_2/(\d+)/$', step_2, name='step_2'),
-    url(r'^step_3/(\d+)/$', step_3, name='step_3'),
-    url(r'^step_4/(\d+)/$', step_4, name='step_4'),
-    url(r'^step_5/(\d+)/$', step_5, name='step_5'),
-    url(r'^step_6/(\d+)/$', step_6, name='step_6'),
-    url(r'^step_7/(\d+)/$', step_7, name='step_7'),
-    url(r'^step_8/(\d+)/$', step_8, name='step_8'),
-    url(r'^step_9/(\d+)/$', step_9, name='step_9'),
-    #public
-    url(r'^recruiting/$', recruiting, name='repository.recruiting'),
-    url(r'^advanced_search/$', advanced_search, name='repository.advanced_search'),
-    url(r'^(?P<trial_fossil_id>[0-9A-Za-z-]+)/$', trial_registered, name='repository.trial_registered'),
-    url(r'^(?P<trial_fossil_id>[0-9A-Za-z-]+)/xml/ictrp/$', trial_ictrp, name='repository.trial_ictrp'),
-    url(r'^(?P<trial_fossil_id>[0-9A-Za-z-]+)/xml/ot/$', trial_otxml, name='repository.trial_otxml'),
-    url(r'^(?P<trial_fossil_id>[0-9A-Za-z-]+)/v(?P<trial_version>\d+)/$', trial_registered, name='repository.trial_registered_version'),
-    url(r'^(?P<trial_fossil_id>[0-9A-Za-z-]+)/v(?P<trial_version>\d+)/xml/ictrp/$', trial_ictrp, name='repository.trial_ictrp_version'),
-    url(r'^(?P<trial_id>[0-9A-Za-z-]+)/v(?P<trial_version>\d+)/xml/opentrials/$', trial_otxml, name='repository.trial_otxml_version'),
-    url(r'^all/xml/ictrp$', all_trials_ictrp),
-    url(r'^multi/xml/ot', multi_otxml, name='repository.multi_otxml'),
-    url(r'^multi/csv/ot', custom_otcsv, name='repository.custom_otcsv'),
-    url(r'^$', index, name='repository.index'),
-)
+urlpatterns = [
+    path('edit/<int:trial_pk>/', edit_trial_index, name='repository.edittrial'),
+    path('view/<int:trial_pk>/', trial_view, name='repository.trialview'),
+    path('new_institution/', new_institution, name='new_institution'),
+    path('contacts/', contacts, name='contacts'),
+    path('step_1/<int:trial_pk>/', step_1, name='step_1'),
+    path('step_2/<int:trial_pk>/', step_2, name='step_2'),
+    path('step_3/<int:trial_pk>/', step_3, name='step_3'),
+    path('step_4/<int:trial_pk>/', step_4, name='step_4'),
+    path('step_5/<int:trial_pk>/', step_5, name='step_5'),
+    path('step_6/<int:trial_pk>/', step_6, name='step_6'),
+    path('step_7/<int:trial_pk>/', step_7, name='step_7'),
+    path('step_8/<int:trial_pk>/', step_8, name='step_8'),
+    path('step_9/<int:trial_pk>/', step_9, name='step_9'),
+    # public
+    path('recruiting/', recruiting, name='repository.recruiting'),
+    path('advanced_search/', advanced_search, name='repository.advanced_search'),
+    re_path(r'^(?P<trial_fossil_id>[0-9A-Za-z-]+)/$', trial_registered, name='repository.trial_registered'),
+    re_path(r'^(?P<trial_fossil_id>[0-9A-Za-z-]+)/xml/ictrp/$', trial_ictrp, name='repository.trial_ictrp'),
+    re_path(r'^(?P<trial_fossil_id>[0-9A-Za-z-]+)/xml/ot/$', trial_otxml, name='repository.trial_otxml'),
+    re_path(r'^(?P<trial_fossil_id>[0-9A-Za-z-]+)/v(?P<trial_version>\d+)/$', trial_registered, name='repository.trial_registered_version'),
+    re_path(r'^(?P<trial_fossil_id>[0-9A-Za-z-]+)/v(?P<trial_version>\d+)/xml/ictrp/$', trial_ictrp, name='repository.trial_ictrp_version'),
+    re_path(r'^(?P<trial_id>[0-9A-Za-z-]+)/v(?P<trial_version>\d+)/xml/opentrials/$', trial_otxml, name='repository.trial_otxml_version'),
+    path('all/xml/ictrp', all_trials_ictrp),
+    re_path(r'^multi/xml/ot', multi_otxml, name='repository.multi_otxml'),
+    re_path(r'^multi/csv/ot', custom_otcsv, name='repository.custom_otcsv'),
+    path('', index, name='repository.index'),
+]

--- a/opentrials/repository/views.py
+++ b/opentrials/repository/views.py
@@ -11,7 +11,7 @@ from django.http import HttpResponseRedirect, HttpResponse, Http404
 from django.shortcuts import render_to_response, get_object_or_404
 from django.utils.translation import gettext_lazy as _
 from django.forms.models import inlineformset_factory
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.template import loader

--- a/opentrials/reviewapp/tests/02-workflow.txt
+++ b/opentrials/reviewapp/tests/02-workflow.txt
@@ -10,7 +10,7 @@ This test aims to be the story test that implement the workflow you can found at
     >>> from django.utils import simplejson
     >>> from django.test.client import Client
     >>> from django.contrib.auth.models import User, Group
-    >>> from django.core.urlresolvers import reverse
+    >>> from django.urls import reverse
     >>> from django.conf import settings
     >>> from django.contrib.contenttypes.models import ContentType
 

--- a/opentrials/reviewapp/urls.py
+++ b/opentrials/reviewapp/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.urls import path, re_path
 from django.contrib.auth.views import login, logout
 from django.contrib.auth.views import password_reset, password_reset_done
 from django.contrib.auth.views import password_reset_complete, password_reset_confirm
@@ -20,84 +20,84 @@ submissions = {
    'queryset':Submission.objects.all()
 }
 
-urlpatterns = patterns('',
+urlpatterns = [
 
-    url(r'^news/$', news_list, name='reviewapp.newslist'),
+    path('news/', news_list, name='reviewapp.newslist'),
 
-    url(r'^news/(?P<object_id>\d+)/$', news_detail, name='reviewapp.news'),
+    path('news/<int:object_id>/', news_detail, name='reviewapp.news'),
 
-    url(r'^accounts/dashboard/$', dashboard, name='reviewapp.dashboard'),
+    path('accounts/dashboard/', dashboard, name='reviewapp.dashboard'),
 
-    url(r'^accounts/profile/$', user_profile, name='reviewapp.userhome'),
+    path('accounts/profile/', user_profile, name='reviewapp.userhome'),
 
-    url(r'^accounts/uploadtrial/$', upload_trial, name='reviewapp.uploadtrial'), #same as accounts/profile
+    path('accounts/uploadtrial/', upload_trial, name='reviewapp.uploadtrial'), #same as accounts/profile
 
-    url(r'^accounts/submissionlist/$', submissions_list, name='reviewapp.submissionlist'), #same as accounts/profile
-    url(r'^accounts/reviewlist/$', reviewlist, name='reviewapp.reviewlist'),
+    path('accounts/submissionlist/', submissions_list, name='reviewapp.submissionlist'), #same as accounts/profile
+    path('accounts/reviewlist/', reviewlist, name='reviewapp.reviewlist'),
 
-   url(r'^accounts/allsubmissionslist/$', allsubmissionslist, name='reviewapp.allsubmissionslist'), #same as accounts/profile
+    path('accounts/allsubmissionslist/', allsubmissionslist, name='reviewapp.allsubmissionslist'), #same as accounts/profile
 
-    url(r'^accounts/submission/(\d+)/$', submission_detail,
+    path('accounts/submission/<int:pk>/', submission_detail,
         name='reviewapp.submission'),
 
-    url(r'^accounts/submission/delete/(\d+)/$', submission_delete,
+    path('accounts/submission/delete/<int:id>/', submission_delete,
         name='reviewapp.submission_delete'),
 
-    url(r'^accounts/submission/change/(?P<submission_pk>\d+)/(?P<status>[a-z]+)/$', change_submission_status,
+    path('accounts/submission/change/<int:submission_pk>/<slug:status>/', change_submission_status,
         name='reviewapp.change_submission_status'),
 
-    url(r'^accounts/newsubmission/$', new_submission,
+    path('accounts/newsubmission/', new_submission,
         name='reviewapp.new_submission'),
 
-    url(r'^accounts/termsofuse/$', terms_of_use,
+    path('accounts/termsofuse/', terms_of_use,
         name='reviewapp.terms_of_use'),
 
-    url(r'^accounts/submission/edit-published/(\d+)/$', submission_edit_published,
+    path('accounts/submission/edit-published/<int:pk>/', submission_edit_published,
         name='reviewapp.submission_edit_published'),
 
-    url(r'^accounts/userdump/$', user_dump),
+    path('accounts/userdump/', user_dump),
 
-    url(r'^accounts/login/$', login, dict(template_name='reviewapp/login.html',redirect_field_name='/'),
+    path('accounts/login/', login, dict(template_name='reviewapp/login.html',redirect_field_name='/'),
         name='reviewapp.login'),
 
-    url(r'^accounts/logout/$', logout, dict(next_page='/'),
+    path('accounts/logout/', logout, dict(next_page='/'),
         name='reviewapp.logout'),
 
-    url(r'^accounts/resend/activation/email/$', resend_activation_email,
+    path('accounts/resend/activation/email/', resend_activation_email,
         name='reviewapp.resend_activation_email'),
 
-    url(r'^accounts/password/reset/$', password_reset, {
+    path('accounts/password/reset/', password_reset, {
         'template_name': 'reviewapp/password_reset_form.html',
         'email_template_name': 'reviewapp/password_reset_email.html',
         'post_reset_redirect': '/accounts/password/reset/done/'},
         name='reviewapp.password_reset'),
 
-    url(r'^accounts/password/reset/done/$', password_reset_done,
+    path('accounts/password/reset/done/', password_reset_done,
         {'template_name': 'reviewapp/password_reset_done.html'},
         name='reviewapp.password_reset_done'),
 
-    url(r'^accounts/password/reset/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$', password_reset_confirm, {
+    re_path(r'^accounts/password/reset/(?P<uidb36>[0-9A-Za-z]+)-(?P<token>.+)/$', password_reset_confirm, {
         'template_name': 'reviewapp/password_reset_confirm.html',
         'post_reset_redirect': '/accounts/password/reset/complete/'},
         name='reviewapp.password_reset_confirm'),
 
-    url(r'^accounts/password/reset/complete/$', password_reset_complete,
+    path('accounts/password/reset/complete/', password_reset_complete,
         {'template_name': 'reviewapp/password_reset_complete.html'},
         name='reviewapp.password_reset_complete'),
 
-    url(r'^remark/open/(?P<submission_id>\d+)/(?P<context>[a-zA-Z0-9_\- ]+)/$', open_remark,
+    re_path(r'^remark/open/(?P<submission_id>\d+)/(?P<context>[a-zA-Z0-9_\- ]+)/$', open_remark,
         name='reviewapp.openremark'),
 
-    url(r'^contact/$', contact, name='reviewapp.contact'),
+    path('contact/', contact, name='reviewapp.contact'),
 
-    url(r'^remark/change/(?P<remark_id>\d+)/(?P<status>[a-z]+)/$', change_remark_status,
+    path('remark/change/<int:remark_id>/<slug:status>/', change_remark_status,
         name='reviewapp.changeremarkstatus'),
 
-    url(r'^remark/delete/(?P<remark_id>\d+)/$', delete_remark,
+    path('remark/delete/<int:remark_id>/', delete_remark,
         name='reviewapp.delete_remark'),
 
-    url(r'^rss/(?P<url>.*)/$', 'django.contrib.syndication.views.feed',
+    re_path(r'^rss/(?P<url>.*)/$', 'django.contrib.syndication.views.feed',
         {'feed_dict': {'trials': LastTrials, 'recruiting': LastRecruiting}}),
 
-    url(r'^$', index, name='reviewapp.home'),
-)
+    path('', index, name='reviewapp.home'),
+]

--- a/opentrials/reviewapp/views.py
+++ b/opentrials/reviewapp/views.py
@@ -2,7 +2,7 @@
 from django.http import Http404, HttpResponse
 from reviewapp.models import UserProfile, REMARK_TRANSITIONS, Remark
 from registration.models import RegistrationProfile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
 from django.shortcuts import render_to_response, get_object_or_404

--- a/opentrials/tickets/urls.py
+++ b/opentrials/tickets/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.urls import path
 from django.views.generic.list_detail import object_detail, object_list
 from tickets.models import Ticket, Followup
 from tickets.views import index, new_iteration, reopen_ticket, resolve_ticket, close_ticket, open_ticket, waiting_acceptance, accept_ticket
@@ -8,16 +8,15 @@ info_dict = {
     'queryset': Ticket.objects.all(),
 }
 
-urlpatterns = patterns('',
-    url(r'^$', index, name="ticket.index"),
-    url(r'^list/$', object_list, info_dict, name="ticket.list"),
-    url(r'^list_waiting/$', waiting_acceptance, name="ticket.waiting_acceptance"),
-    url(r'^history/(?P<object_id>\d+)/$', object_detail, info_dict, name='ticket.history' ),
-    url(r'^open/(?P<context>\w+)/(?P<type>\w+)/$', open_ticket, name='ticket.open' ),
-    url(r'^reopen/(?P<object_id>\d+)/$', reopen_ticket, name='ticket.reopen' ),
-    url(r'^resolve/(?P<object_id>\d+)/$', resolve_ticket, name='ticket.resolve' ),
-    url(r'^accept/(?P<object_id>\d+)/$', accept_ticket, name='ticket.accept' ),
-    url(r'^close/(?P<object_id>\d+)/$', close_ticket, name='ticket.close' ),
-    url(r'^newiteration/(?P<object_id>\d+)/$', new_iteration, name='ticket.new_iteration' ),
-    url(r'^newiteration/(?P<object_id>\d+)/$', new_iteration, name='ticket.new_iteration' ),
-)
+urlpatterns = [
+    path('', index, name="ticket.index"),
+    path('list/', object_list, info_dict, name="ticket.list"),
+    path('list_waiting/', waiting_acceptance, name="ticket.waiting_acceptance"),
+    path('history/<int:object_id>/', object_detail, info_dict, name='ticket.history'),
+    path('open/<str:context>/<str:type>/', open_ticket, name='ticket.open'),
+    path('reopen/<int:object_id>/', reopen_ticket, name='ticket.reopen'),
+    path('resolve/<int:object_id>/', resolve_ticket, name='ticket.resolve'),
+    path('accept/<int:object_id>/', accept_ticket, name='ticket.accept'),
+    path('close/<int:object_id>/', close_ticket, name='ticket.close'),
+    path('newiteration/<int:object_id>/', new_iteration, name='ticket.new_iteration'),
+]


### PR DESCRIPTION
## Summary
- replace legacy `django.conf.urls.defaults` usage with `path`/`re_path` across application URLconfs
- update modules importing `django.core.urlresolvers` to use `django.urls` equivalents
- adjust admin and doctest helpers to align with the new URL APIs

## Testing
- python opentrials/manage.py test *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68d7080287ac8327a8d52f4a63d4f349