### PR TITLE
Modernize string handling to drop unicode prefixes

### DIFF
--- a/opentrials/diagnostic/views.py
+++ b/opentrials/diagnostic/views.py
@@ -122,7 +122,7 @@ def req_dump(request):
 
 @user_passes_test(lambda u: u.is_staff)
 def sys_info(request):
-    template = u'''
+    template = '''
     <h1>Revision</h1>
     %(svn_version)s
     <h1>settings path</h1>
@@ -143,12 +143,12 @@ def sys_info(request):
     from django.contrib.sites.models import Site
     from subprocess import Popen, PIPE
     svn_version, svn_version_err = Popen(['svnversion', settings.PROJECT_PATH], stdout=PIPE).communicate()
-    svn_version = svn_version.decode('utf-8') if svn_version else u''
-    svn_version_err = svn_version_err.decode('utf-8') if svn_version_err else u''
+    svn_version = svn_version.decode('utf-8') if svn_version else ''
+    svn_version_err = svn_version_err.decode('utf-8') if svn_version_err else ''
     site = Site.objects.get_current()
     svnout, svnerr = Popen(['svn', 'info','--non-interactive','--username=anonymous','--password=4guests@','-r', 'HEAD', settings.PROJECT_PATH], stdout=PIPE).communicate()
-    svnout = svnout.decode('utf-8') if svnout else u''
-    svnerr = svnerr.decode('utf-8') if svnerr else u''
+    svnout = svnout.decode('utf-8') if svnout else ''
+    svnerr = svnerr.decode('utf-8') if svnerr else ''
     return HttpResponse(template % {'site.pk':site.pk,
                                     'site.domain':site.domain,
                                     'site.name':site.name,

--- a/opentrials/registration/forms.py
+++ b/opentrials/registration/forms.py
@@ -75,7 +75,7 @@ class RegistrationFormTermsOfService(RegistrationForm):
     
     """
     tos = forms.BooleanField(widget=forms.CheckboxInput(attrs=attrs_dict),
-                             label=_(u'I have read and agree to the Terms of Service'),
+                             label=_('I have read and agree to the Terms of Service'),
                              error_messages={'required': _("You must agree to the terms to register")})
 
 

--- a/opentrials/registration/models.py
+++ b/opentrials/registration/models.py
@@ -160,7 +160,7 @@ class RegistrationProfile(models.Model):
     account registration and activation.
     
     """
-    ACTIVATED = u"ALREADY_ACTIVATED"
+    ACTIVATED = "ALREADY_ACTIVATED"
     
     user = models.OneToOneField(User, on_delete=models.CASCADE, verbose_name=_('user'))
     activation_key = models.CharField(_('activation key'), max_length=40)

--- a/opentrials/registration/tests/forms.py
+++ b/opentrials/registration/tests/forms.py
@@ -25,19 +25,19 @@ class RegistrationFormTests(TestCase):
                       'email': 'foo@example.com',
                       'password1': 'foo',
                       'password2': 'foo'},
-            'error': ('username', [u"This value must contain only letters, numbers and underscores."])},
+            'error': ('username', ["This value must contain only letters, numbers and underscores."])},
             # Already-existing username.
             {'data': {'username': 'alice',
                       'email': 'alice@example.com',
                       'password1': 'secret',
                       'password2': 'secret'},
-            'error': ('username', [u"A user with that username already exists."])},
+            'error': ('username', ["A user with that username already exists."])},
             # Mismatched passwords.
             {'data': {'username': 'foo',
                       'email': 'foo@example.com',
                       'password1': 'foo',
                       'password2': 'bar'},
-            'error': ('__all__', [u"The two password fields didn't match."])},
+            'error': ('__all__', ["The two password fields didn't match."])},
             ]
 
         for invalid_dict in invalid_data_dicts:
@@ -64,7 +64,7 @@ class RegistrationFormTests(TestCase):
                                                           'password2': 'foo'})
         self.failIf(form.is_valid())
         self.assertEqual(form.errors['tos'],
-                         [u"You must agree to the terms to register"])
+                         ["You must agree to the terms to register"])
 
         form = forms.RegistrationFormTermsOfService(data={'username': 'foo',
                                                           'email': 'foo@example.com',
@@ -89,7 +89,7 @@ class RegistrationFormTests(TestCase):
                                                        'password2': 'foo'})
         self.failIf(form.is_valid())
         self.assertEqual(form.errors['email'],
-                         [u"This email address is already in use. Please supply a different email address."])
+                         ["This email address is already in use. Please supply a different email address."])
 
         form = forms.RegistrationFormUniqueEmail(data={'username': 'foo',
                                                        'email': 'foo@example.com',
@@ -108,11 +108,11 @@ class RegistrationFormTests(TestCase):
                      'password2': 'foo'}
         for domain in forms.RegistrationFormNoFreeEmail.bad_domains:
             invalid_data = base_data.copy()
-            invalid_data['email'] = u"foo@%s" % domain
+            invalid_data['email'] = "foo@%s" % domain
             form = forms.RegistrationFormNoFreeEmail(data=invalid_data)
             self.failIf(form.is_valid())
             self.assertEqual(form.errors['email'],
-                             [u"Registration using free email addresses is prohibited. Please supply a different email address."])
+                             ["Registration using free email addresses is prohibited. Please supply a different email address."])
 
         base_data['email'] = 'foo@example.com'
         form = forms.RegistrationFormNoFreeEmail(data=base_data)

--- a/opentrials/registration/tests/views.py
+++ b/opentrials/registration/tests/views.py
@@ -79,7 +79,7 @@ class RegistrationViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.failIf(response.context['form'].is_valid())
         self.assertFormError(response, 'form', field=None,
-                             errors=u"The two password fields didn't match.")
+                             errors="The two password fields didn't match.")
         self.assertEqual(len(mail.outbox), 0)
 
     def test_registration_view_closed(self):

--- a/opentrials/repository/models.py
+++ b/opentrials/repository/models.py
@@ -77,7 +77,7 @@ class TrialRegistrationDataSetModel(ControlledDeletion):
                 content = '<table bgcolor="yellow">%s</table>' % value.html_dump(seen, follow_sets=False)
             else:
                 content = str(value)
-                if u'\n' in content:
+                if '\n' in content:
                     content = linebreaks(content)
             html.append('<tr><th>%s</th><td>%s</td></tr>' % (field.name, content))
         if follow_sets:
@@ -97,7 +97,7 @@ class TrialRegistrationDataSetModel(ControlledDeletion):
                                 content = '<table>%s</table>' % rel_value.html_dump(seen, follow_sets=False)
                             else:
                                 content = str(rel_value)
-                            if u'\n' in content:
+                            if '\n' in content:
                                 content = linebreaks(content)
                             inner_html.append('<tr><th>%s</th><td>%s</td></tr>' % (id, content))
                         content = '<table>%s</table>' % '\n\t'.join(inner_html)
@@ -352,7 +352,7 @@ class ClinicalTrial(TrialRegistrationDataSetModel):
 
     # TRDS 11 - Countries of Recruitment
     recruitment_country = models.ManyToManyField(CountryCode,
-        help_text=u'Several countries may be selected, one at a time')
+        help_text='Several countries may be selected, one at a time')
 
     #Observational filelds
     is_observational = models.BooleanField(default=False, null=False)
@@ -414,8 +414,7 @@ class ClinicalTrial(TrialRegistrationDataSetModel):
         return safe_truncate(self.main_title(), 120)
 
     def very_short_title(self):
-        tit = u'%s - %s' % (self.identifier(),
-                            self.short_title())
+        tit = f"{self.identifier()} - {self.short_title()}"
         return safe_truncate(tit, 60)
 
     def main_title(self):
@@ -436,13 +435,13 @@ class ClinicalTrial(TrialRegistrationDataSetModel):
 
     def acronym_display(self):
         if self.acronym_expansion:
-            return u'%s: %s' % (self.acronym, self.acronym_expansion)
+            return f"{self.acronym}: {self.acronym_expansion}"
         else:
             return self.acronym
 
     def scientific_acronym_display(self):
         if self.scientific_acronym_expansion:
-            return u'%s: %s' % (self.scientific_acronym, self.scientific_acronym_expansion)
+            return f"{self.scientific_acronym}: {self.scientific_acronym_expansion}"
         else:
             return self.scientific_acronym
 
@@ -673,8 +672,8 @@ class Contact(TrialRegistrationDataSetModel):
     creator = models.ForeignKey(User, related_name='contact_creator', editable=False)
 
     def name(self):
-        names = self.firstname + u' ' + self.middlename + u' ' + self.lastname
-        return u' '.join(names.split())
+        names = self.firstname + ' ' + self.middlename + ' ' + self.lastname
+        return ' '.join(names.split())
 
     def __str__(self):
         return self.name()

--- a/opentrials/repository/templatetags/repository_tags.py
+++ b/opentrials/repository/templatetags/repository_tags.py
@@ -43,7 +43,7 @@ class ForTranslationNode(template.Node):
 
                 output.append(self.nodelist.render(context))
 
-        return u'\n'.join(output)
+        return '\n'.join(output)
 
     def get_value(self, obj, key):
         try:

--- a/opentrials/repository/tests/__init__.py
+++ b/opentrials/repository/tests/__init__.py
@@ -12,12 +12,12 @@ class SecondaryNumbers(TestCase):
     fixtures = ['first_3_trials.json']
 
     def setUp(self):
-        title = u'Comparison of Ascorbic Acid and Grape Seed'
+        title = 'Comparison of Ascorbic Acid and Grape Seed'
         self.asc_trial = ClinicalTrial.objects.get(
             public_title__istartswith=title)
 
     def test_short_title(self):
-        start = u'Effect of Ascorbic Acid'
+        start = 'Effect of Ascorbic Acid'
         self.assertTrue(self.asc_trial.short_title().startswith(start))
 
     def test_secondary_numbers(self):
@@ -26,12 +26,12 @@ class SecondaryNumbers(TestCase):
     def test_public_contacts(self):
         contacts = list(self.asc_trial.public_contacts())
         self.assertEquals(len(contacts), 1)
-        self.assertEquals(contacts[0].firstname, u'Naser')
+        self.assertEquals(contacts[0].firstname, 'Naser')
 
     def test_scientific_contacts(self):
         contacts = list(self.asc_trial.scientific_contacts())
         self.assertEquals(len(contacts), 1)
-        self.assertEquals(contacts[0].firstname, u'Naser')
+        self.assertEquals(contacts[0].firstname, 'Naser')
 
 class Step3Test(TestCase):
     fixtures = ['first_3_trials.json']

--- a/opentrials/repository/trds_forms.py
+++ b/opentrials/repository/trds_forms.py
@@ -48,7 +48,7 @@ class ReviewModelForm(MultilingualBaseForm):
             bf_errors = self.error_class([conditional_escape(error) for error in bf.errors]) # Escape and cache in local variable.
             if bf.is_hidden:
                 if bf_errors:
-                    top_errors.extend([u'(Hidden field %s) %s' % (name, force_str(e)) for e in bf_errors])
+                    top_errors.extend(['(Hidden field %s) %s' % (name, force_str(e)) for e in bf_errors])
                 hidden_fields.append(str(bf))
             else:
                 if errors_on_separate_row and bf_errors:
@@ -83,7 +83,7 @@ class ReviewModelForm(MultilingualBaseForm):
                 if field.help_text:
                     help_text = help_text_html % force_str(field.help_text)
                 else:
-                    help_text = u''
+                    help_text = ''
                 form_name = self.__class__.__name__
                 help_record, new = FieldHelp.objects.get_or_create(form=form_name, field=name)
 
@@ -122,7 +122,7 @@ class ReviewModelForm(MultilingualBaseForm):
         if top_errors:
             output.insert(0, error_row % force_str(top_errors))
         if hidden_fields: # Insert any hidden fields in the last row.
-            str_hidden = u''.join(hidden_fields)
+            str_hidden = ''.join(hidden_fields)
 
             if output:
                 last_row = output[-1]
@@ -146,20 +146,20 @@ class ReviewModelForm(MultilingualBaseForm):
                 # hidden fields.
                 output.append(str_hidden)
 
-        return mark_safe(u'\n'.join(output))
+        return mark_safe('\n'.join(output))
 
     def as_table(self):
         "Returns this form rendered as HTML <tr>s -- excluding the <table></table>."
-        normal_row = u'''
+        normal_row = '''
             <tr class="%(field_class)s %(field_name)s"><th><img src="/static/help.png" rel="#%(help_id)s"/>
                     <div id="%(help_id)s" class="help">%(help_text)s</div>
                     %(label)s</th>
                 <td>%(errors)s%(field)s
                 </td></tr>'''
         return self._html_output(normal_row=normal_row,
-                                 error_row=u'<tr><td colspan="3">%s</td></tr>',
+                                 error_row='<tr><td colspan="3">%s</td></tr>',
                                  row_ender='</td></tr>',
-                                 help_text_html=u'%s',
+                                 help_text_html='%s',
                                  errors_on_separate_row=False)
 
 #

--- a/opentrials/repository/views.py
+++ b/opentrials/repository/views.py
@@ -395,18 +395,18 @@ def get_humanizer(language_code, min_age_unit, max_age_unit):
             #see the index view callable
             humanized = [_('Inclusion Minimum Age')]
             try:
-                humanized.append(u'%s %s' % (denormalize_age(value, min_age_unit), age_unit_labels[min_age_unit]))
+                humanized.append(f"{denormalize_age(value, min_age_unit)} {age_unit_labels[min_age_unit]}")
             except KeyError:
-                humanized.append(u'%s %s' % (denormalize_age(value, 'Y'), age_unit_labels['Y']))
+                humanized.append(f"{denormalize_age(value, 'Y')} {age_unit_labels['Y']}")
             return humanized
         elif key == 'minimum_recruitment_age__lte':
             #due to the logic applied to the query, the key names are inverted (min an max age)
             #see the index view callable
             humanized = [_('Inclusion Maximum Age')]
             try:
-                humanized.append(u'%s %s' % (denormalize_age(value, max_age_unit), age_unit_labels[max_age_unit]))
+                humanized.append(f"{denormalize_age(value, max_age_unit)} {age_unit_labels[max_age_unit]}")
             except KeyError:
-                humanized.append(u'%s %s' % (denormalize_age(value, 'Y'), age_unit_labels['Y']))
+                humanized.append(f"{denormalize_age(value, 'Y')} {age_unit_labels['Y']}")
             return humanized
         else:
             return [key, default_str]

--- a/opentrials/repository/widgets.py
+++ b/opentrials/repository/widgets.py
@@ -16,13 +16,13 @@ class SelectWithLink(forms.widgets.Select):
         if value is None: 
             value = ''
         final_attrs = self.build_attrs(attrs, name=name)
-        output = [u'<select%s>' % flatatt(final_attrs)]
+        output = ['<select%s>' % flatatt(final_attrs)]
         options = self.render_options(choices, [value])
         if options:
             output.append(options)
-        output.append(u'</select>')
-        output.append(u'<span><a href="%s" id="%s-link" style="display: inline;">%s</a></span>' % (self.link, name, self.text))
-        return mark_safe(u'\n'.join(output))
+        output.append('</select>')
+        output.append('<span><a href="%s" id="%s-link" style="display: inline;">%s</a></span>' % (self.link, name, self.text))
+        return mark_safe('\n'.join(output))
         
         
 class SelectInstitution(forms.widgets.Select):
@@ -36,13 +36,13 @@ class SelectInstitution(forms.widgets.Select):
         if value is None: 
             value = ''
         final_attrs = self.build_attrs(attrs, name=name)
-        output = [u'<select%s>' % flatatt(final_attrs)]
+        output = ['<select%s>' % flatatt(final_attrs)]
         options = self.render_options(choices, [value])
         if options:
             output.append(options)
-        output.append(u'</select>')
-        output.append(u'<span><input id="button_new_institution" onclick="%s" type="button" value="%s"/><span>' % (self.func, self.button_label))
-        return mark_safe(u'\n'.join(output))
+        output.append('</select>')
+        output.append('<span><input id="button_new_institution" onclick="%s" type="button" value="%s"/><span>' % (self.func, self.button_label))
+        return mark_safe('\n'.join(output))
         
 class YearMonthWidget(forms.MultiWidget):
     """

--- a/opentrials/reviewapp/admin.py
+++ b/opentrials/reviewapp/admin.py
@@ -18,10 +18,10 @@ class AdminFileLinkWidget(admin.widgets.AdminFileWidget):
         output = []
         if value and hasattr(value, "url"):
             output.append('<a target="_blank" href="%s">%s</a>' % \
-                           (value.url.replace(PROJECT_PATH, u''), \
-                            value.url.replace(PROJECT_PATH, u'').split("/")[-1], \
+                           (value.url.replace(PROJECT_PATH, ''), \
+                            value.url.replace(PROJECT_PATH, '').split("/")[-1], \
                            ))
-        return mark_safe(u''.join(output))
+        return mark_safe(''.join(output))
 
 class RecruitmentCountryInline(admin.TabularInline):
     model = RecruitmentCountry

--- a/opentrials/reviewapp/models.py
+++ b/opentrials/reviewapp/models.py
@@ -53,10 +53,10 @@ class UserProfile(models.Model):
                                 default=settings.MANAGED_LANGUAGES_CHOICES[-1][0])
 
     def amount_submissions(self):
-        return u"%03d" % (Submission.objects.filter(creator=self.user).count())
+        return "%03d" % (Submission.objects.filter(creator=self.user).count())
 
     def amount_tickets(self):
-        return u"%03d" % (Ticket.objects.filter(creator=self.user).count())
+        return "%03d" % (Ticket.objects.filter(creator=self.user).count())
 
 class Submission(ControlledDeletion):
     class Meta:
@@ -69,7 +69,7 @@ class Submission(ControlledDeletion):
     created = models.DateTimeField(default=datetime.now, editable=False)
     updater = models.ForeignKey(User, null=True, related_name='submission_updater', editable=False)
     updated = models.DateTimeField(null=True, editable=False)
-    title = models.TextField(u'Scientific title', max_length=2000)
+    title = models.TextField('Scientific title', max_length=2000)
     primary_sponsor = models.ForeignKey(Institution, null=True, blank=True,
                                     verbose_name=_('Primary Sponsor'))
 
@@ -104,7 +104,7 @@ class Submission(ControlledDeletion):
         return self.short_title()
 
     def get_mandatory_languages(self):
-        langs = set([u'en'])
+        langs = {'en'}
         if self.trial.primary_sponsor is not None:
             langs.add(self.trial.primary_sponsor.country.submission_language)
 
@@ -192,7 +192,7 @@ class Attachment(models.Model):
     public = models.BooleanField(_('Public'))
 
     def get_relative_url(self):
-        return self.file.url.replace(settings.PROJECT_PATH, u'')
+        return self.file.url.replace(settings.PROJECT_PATH, '')
 
     def __str__(self):
         return str(self.description)

--- a/opentrials/settings.py
+++ b/opentrials/settings.py
@@ -165,7 +165,7 @@ AUTH_PROFILE_MODULE = "reviewapp.UserProfile"
 # in opentrials/fixtures/initial_data.json
 SITE_ID = 2 # change if necessary to match a record in django_site
 
-SITE_TITLE = u'Registro Brasileiro de Ensaios Clínicos'
+SITE_TITLE = 'Registro Brasileiro de Ensaios Clínicos'
 SEND_BROKEN_LINK_EMAILS = True
 DECS_SERVICE = 'http://decs.bvs.br/cgi-bin/mx/cgi=@vmx/decs'
 ICD10_SERVICE = 'http://bases.bireme.br/cgi-bin/mxlindG4.exe/cgi=@cid10/cid10'
@@ -178,15 +178,15 @@ TRIAL_ID_DIGITS = 6
 # 2) the first managed language is considered the default and is
 #    also the source language for content translation purposes
 MANAGED_LANGUAGES_CHOICES = (
-    (u'en', u'English'),
-    (u'es', u'Español'),
-    (u'pt-br', u'Português'),
+    ('en', 'English'),
+    ('es', 'Español'),
+    ('pt-br', 'Português'),
 )
 TARGET_LANGUAGES = MANAGED_LANGUAGES_CHOICES[1:] # exlude source language
 MANAGED_LANGUAGES = [code for code, label in MANAGED_LANGUAGES_CHOICES]
 # TODO: implement this as default on new submission forms
 #LANGUAGES = MANAGED_LANGUAGES_CHOICES
-DEFAULT_SUBMISSION_LANGUAGE = u'en'
+DEFAULT_SUBMISSION_LANGUAGE = 'en'
 
 # django-registration: for how long the activation link is valid
 ACCOUNT_ACTIVATION_DAYS = 7

--- a/opentrials/utilities.py
+++ b/opentrials/utilities.py
@@ -22,24 +22,24 @@
 from django.http import HttpResponse
 from django.core import serializers
 
-ELLIPSIS = u'\u2026'
+ELLIPSIS = '\u2026'
 
 def safe_truncate(text, max_length=60, ellipsis=ELLIPSIS, encoding='utf-8',
                   raise_exc=False):
-    u'''truncate a string without breaking words
+    '''truncate a string without breaking words
 
-        >>> safe_truncate(u'the time has come', 9, u'>')
-        u'the time>'
-        >>> safe_truncate(u'the-time-has-come', 9, u'>')
-        u'the-time>'
-        >>> safe_truncate(u'the time', 8)
-        u'the time'
-        >>> safe_truncate(u'the time', 9)
-        u'the time'
-        >>> s = u'uncharacteristically-long'
-        >>> safe_truncate(s, 10, u'>')
-        u'uncharacteristically>'
-        >>> safe_truncate(s, 10, u'>', raise_exc=True)
+        >>> safe_truncate('the time has come', 9, '>')
+        'the time>'
+        >>> safe_truncate('the-time-has-come', 9, '>')
+        'the-time>'
+        >>> safe_truncate('the time', 8)
+        'the time'
+        >>> safe_truncate('the time', 9)
+        'the time'
+        >>> s = 'uncharacteristically-long'
+        >>> safe_truncate(s, 10, '>')
+        'uncharacteristically>'
+        >>> safe_truncate(s, 10, '>', raise_exc=True)
         Traceback (most recent call last):
           ...
         ValueError: Cannot safely truncate to 10 characters


### PR DESCRIPTION
## Summary
- replace unicode-prefixed literals and string formatting with native `str` usage across repository widgets, forms, and admin utilities
- refresh helper utilities, tests, and settings to align with Python 3 `__str__` expectations and plain string constants
- update docstring examples and string joins to avoid legacy unicode handling

## Testing
- python -m compileall opentrials *(fails: legacy Python 2-only scripts under `fixtures/` and other maintenance utilities still contain `print` statements without parentheses)*

------
https://chatgpt.com/codex/tasks/task_e_68d70a82c01c8327a3d869e398d11029