### PR TITLE
Modernize Django manage.py entrypoint

### DIFF
--- a/opentrials/manage.py
+++ b/opentrials/manage.py
@@ -1,11 +1,16 @@
-#!/usr/bin/env python
-from django.core.management import execute_manager
-try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
+#!/usr/bin/env python3
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main() -> None:
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "opentrials.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)
+
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    main()


### PR DESCRIPTION
## Summary
- replace legacy execute_manager usage with the current execute_from_command_line boilerplate
- ensure the script defines a main() function guarded by __name__ == "__main__"
- update the shebang to invoke Python 3 explicitly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8119024c08327ad7d9b8da96dde26