### PR TITLE
Modernize manage.py entrypoint

### DIFF
--- a/opentrials/manage.py
+++ b/opentrials/manage.py
@@ -1,11 +1,26 @@
 #!/usr/bin/env python
-from django.core.management import execute_manager
+"""Django's command-line utility for administrative tasks."""
+
+import os
+import sys
+
 try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
+    from django.core.management import execute_from_command_line
+except ImportError as exc:
+    raise ImportError(
+        "Couldn't import Django. Are you sure it's installed and available on your "
+        "PYTHONPATH environment variable? Did you forget to activate a virtual "
+        "environment?"
+    ) from exc
+
+
+def main():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    import django
+
+    django.setup()
+    execute_from_command_line(sys.argv)
+
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    main()


### PR DESCRIPTION
## Summary
- update the Django manage.py script to use execute_from_command_line and modern initialization
- ensure the settings module is set before running commands and initialize Django

## Testing
- `python manage.py check` *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d81556899483279499a3122235b439