### PR TITLE
Improve local settings handling and attachment setup

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -51,6 +51,23 @@ We suggest you read a more detailed page at:
     http://reddes.bvsalud.org/projects/clinical-trials/wiki/HowToInstall
 
 
+Local configuration
+-------------------
+
+The default settings now ship with a safe SQLite database that lives inside
+the project tree.  This allows the test suite or ad-hoc development servers to
+run without any additional configuration.  To override these defaults create a
+``settings_local.py`` module (or reuse the legacy ``settings_local.include``)
+alongside ``opentrials/settings.py``.  The
+``opentrials/settings_local.include-SAMPLE`` file documents the options that a
+deployment typically needs to provide.
+
+During startup the project will also ensure that the
+``static/attachments`` directory exists.  Confirm that the account running the
+application can write to that directory so user uploads continue to work in
+production environments.
+
+
 virtualenv/setuptools
 ---------------------
 

--- a/opentrials/settings_local.include-SAMPLE
+++ b/opentrials/settings_local.include-SAMPLE
@@ -1,3 +1,6 @@
+# Rename this file to ``settings_local.py`` (recommended) or copy its contents
+# to ``settings_local.include`` if you prefer the legacy include-based loader.
+
 DEBUG = True
 
 SITE_ID = 2 # change if necessary to match a record in django_site
@@ -43,7 +46,10 @@ GOOGLE_ANALYTICS_ID = ''
 #CUSTOM_TEMPLATE_DIR = os.path.join(PROJECT_PATH, 'custom/ecgovbr/templates')
 #TEMPLATES[0]['DIRS'] = [CUSTOM_TEMPLATE_DIR] + TEMPLATES[0]['DIRS']
 
-# Backup directory
+# Backup directory.  When left untouched the default settings will create the
+# ``static/attachments`` tree automatically and fall back to a SQLite database
+# suitable for development and automated testing environments.  Override these
+# values here as needed by your deployment.
 BACKUP_DIR = os.path.join(MEDIA_ROOT, 'backup')
 
 if DEBUG:


### PR DESCRIPTION
## Summary
- load optional local settings via settings_local.py with legacy include fallback and default SQLite configuration
- ensure the attachments directory is created or logged instead of raising during import and log helpful warnings
- document the new defaults and configuration workflow for deployments

## Testing
- python -m compileall opentrials/settings.py

------
https://chatgpt.com/codex/tasks/task_e_68d8166bf5448327bc34339bcc266dcc