### PR TITLE
Switch settings to use localflavor package

### DIFF
--- a/opentrials/settings.py
+++ b/opentrials/settings.py
@@ -23,7 +23,7 @@ import os
 from pathlib import Path
 import warnings
 
-from django_localflavor.br import br_states
+from localflavor.br import br_states
 
 DEBUG = False
 PROJECT_PATH = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
## Summary
- replace the Django localflavor import in the settings module with the package provided import

## Testing
- python opentrials/manage.py check *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d819dad48c8327b285c3ed52c6cb3a